### PR TITLE
Add --print-queries flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 all: gifs
 
-VERSION=v0.1.14
+VERSION=v0.1.0
 
 TAPES=$(shell ls doc/vhs/*tape)
 gifs: $(TAPES)

--- a/Makefile
+++ b/Makefile
@@ -35,14 +35,14 @@ tag-patch:
 
 release:
 	git push --tags
-	GOPROXY=proxy.golang.org go list -m github.com/go-go-golems/XXX@$(shell svu current)
+	GOPROXY=proxy.golang.org go list -m github.com/go-go-golems/oak@$(shell svu current)
 
 bump-glazed:
 	go get github.com/go-go-golems/glazed@latest
 	go get github.com/go-go-golems/clay@latest
 	go mod tidy
 
-XXX_BINARY=$(shell which XXX)
+OAK_BINARY=$(shell which oak)
 install:
-	go build -o ./dist/XXX ./cmd/XXX && \
-		cp ./dist/XXX $(XXX_BINARY)
+	go build -o ./dist/oak ./cmd/oak && \
+		cp ./dist/oak $(OAK_BINARY)

--- a/cmd/oak/main.go
+++ b/cmd/oak/main.go
@@ -190,54 +190,6 @@ func registerLegacyCommands() {
 	var queryFile string
 	var templateFile string
 
-	//runCmd := &cobra.Command{
-	//	Use:   "run",
-	//	Short: "Run an oak command against an input file",
-	//	Args:  cobra.MinimumNArgs(1),
-	//	Run: func(cmd *cobra.Command, args []string) {
-	//		// load queries
-	//		f, err := os.Open(queryFile)
-	//		cobra.CheckErr(err)
-	//
-	//		loader := &pkg.OakCommandLoader{}
-	//		cmds_, err := loader.LoadCommandFromYAML(f)
-	//		cobra.CheckErr(err)
-	//		if len(cmds_) != 1 {
-	//			cobra.CheckErr(fmt.Errorf("expected exactly one command"))
-	//		}
-	//		oak := cmds_[0].(*pkg.OakCommand)
-	//
-	//		for _, inputFile := range args {
-	//			sourceCode, err := readFileOrStdin(inputFile)
-	//			cobra.CheckErr(err)
-	//
-	//			ctx := context.Background()
-	//			tree, err := oak.Parse(ctx, sourceCode)
-	//			cobra.CheckErr(err)
-	//
-	//			results, err := oak.ExecuteQueries(tree.RootNode(), oak.Queries, sourceCode)
-	//			cobra.CheckErr(err)
-	//
-	//			// render template if provided
-	//			var s string
-	//			if templateFile != "" {
-	//				s, err = oak.RenderWithTemplateFile(results, templateFile)
-	//			} else {
-	//				s, err = oak.Render(results)
-	//			}
-	//			cobra.CheckErr(err)
-	//
-	//			fmt.Println(s)
-	//		}
-	//	},
-	//}
-	//
-	//runCmd.Flags().StringVarP(&queryFile, "query-file", "q", "", "SitterQuery file path")
-	//err := runCmd.MarkFlagRequired("query-file")
-	//cobra.CheckErr(err)
-	//
-	//runCmd.Flags().StringVarP(&templateFile, "template", "t", "", "Template file path")
-
 	queryCmd := &cobra.Command{
 		Use:   "query",
 		Short: "SitterQuery a source code file with a plain sitter query",

--- a/pkg/cmd.go
+++ b/pkg/cmd.go
@@ -85,7 +85,7 @@ func (o *OakCommandLoader) LoadCommandFromYAML(
 				"sources",
 				parameters.ParameterTypeStringList,
 				parameters.WithHelp("Files (or directories if recursing) to parse"),
-				parameters.WithRequired(true),
+				parameters.WithRequired(false),
 			),
 		),
 		cmds.WithLayout(&layout.Layout{

--- a/pkg/layers/oak.yaml
+++ b/pkg/layers/oak.yaml
@@ -7,7 +7,7 @@ flags:
     type: bool
     help: Recurse into subdirectories
     default: false
-  - name: glazed
+  - name: print-queries
     type: bool
-    help: Output data as glazed table
+    help: Print queries
     default: false


### PR DESCRIPTION
Closes #8

- :art: Tag for release v0.1.0
- :art: Make the sources list be optional so that we can pass an empty list for the --print-queries command. This shouldn't be an issue since we don't want users to provide their own arguments any way.
- :sparkles: Implement --print-queries to print out the queries as YAML
- :art: Update the Makefile to have no XXX, remove deprecated documentation
